### PR TITLE
Resolves #7: Join Contacts to Core Tables

### DIFF
--- a/electron/app/addressBro/util/index.ts
+++ b/electron/app/addressBro/util/index.ts
@@ -68,7 +68,7 @@ export async function setContactNameColumn(db:sqlite3.Database) {
   `UPDATE handle SET ${ContactNameColumns.CONTACT_NAME} = (
     SELECT ${addressBookDBAliasName}.${AddressBookTableNames.CONTACT_TABLE}.${ContactNameColumns.CONTACT_NAME}
       FROM ${addressBookDBAliasName}.${AddressBookTableNames.CONTACT_TABLE}
-        WHERE ${normalizePhoneNumberStatement(`handle.id`)}
+    WHERE ${normalizePhoneNumberStatement(`handle.id`)}
     = ${addressBookDBAliasName}.${AddressBookTableNames.CONTACT_TABLE}.${ContactNameColumns.CONTACT_PHONE}
     )`;
   await sqlite3Wrapper.runP(db, SET_CONTACT_NAME_COLUMN_QUERY);

--- a/electron/app/chatBro/constants/stopWords.ts
+++ b/electron/app/chatBro/constants/stopWords.ts
@@ -30,7 +30,6 @@ const stopWordsList = [
   '',
   ' ',
   'lets',
-
   'u',
   'would',
   'like',
@@ -167,6 +166,10 @@ const stopWordsList = [
   'should',
   'now',
   'much',
+  "it’s",
+  "you’re",
+  "can’t",
+  "I’m",
   '”', // very weird quote, not sure what this is
 ];
 export const stopWords = delimList(stopWordsList);

--- a/electron/app/chatBro/queries/WordCount/WordCount.ts
+++ b/electron/app/chatBro/queries/WordCount/WordCount.ts
@@ -35,10 +35,10 @@ export async function queryWordCounts(
   tableName: ChatTableNames.WORD_TABLE,
   opts: WordCountTypes.Options = {}
 ): Promise<WordCountTypes.Results> {
-  const limit = opts.limit || 5;
+  const limit = opts.limit || 10;
   const filters = getAllFilters(opts);
   const query = `
-    SELECT SUM(${Columns.COUNT}) as count,
+    SELECT SUM(${Columns.COUNT}) as ${Columns.COUNT},
     ${Columns.WORD}
     FROM ${tableName}
     ${filters}

--- a/electron/app/db/index.ts
+++ b/electron/app/db/index.ts
@@ -9,7 +9,7 @@ export function initializeDB(path: string): sqlite3.Database {
   return db;
 }
 
-export default function closeDB(db: sqlite3.Database) {
+export function closeDB(db: sqlite3.Database) {
   log.info('Closing DB');
   db.close();
 }

--- a/electron/app/tables/ContactTable.ts
+++ b/electron/app/tables/ContactTable.ts
@@ -1,16 +1,15 @@
 import * as sqlite3Wrapper from '../utils/initUtils/sqliteWrapper';
 import { TableNames } from './definitions';
 import { Table } from './Table';
+import { normalizePhoneNumberStatement } from '../utils/initUtils/constants/normalization'
 
 /*
- * NOTE: in the chat.db the format is +1619... in other words
- * chat.db lists the country code always.
+ * NOTE: the chat.db lists the country code always.
  * The addressbook.db, however, does not always include the country code.
- * Therefore, we remove the + and the country code, and FILTER on the 10-digit length.
+ * Therefore, we join on a normalized column that r
  * All phone numbers in the US/Canada are 10-digit...
- *  this assumption may not work as well for users in other countries
+ *  this assumption will not work as well for users in other countries
  */
-const PHONE_NUMBER_LENGTH = '10';
 
 export class ContactTable extends Table {
   async create(): Promise<TableNames> {
@@ -22,17 +21,16 @@ export class ContactTable extends Table {
       ZABCDRECORD.ZFIRSTNAME,
       ZABCDRECORD.ZLASTNAME,
       -- TODO: I understand this is ugly... use regex.
-      replace(replace(replace(replace(replace(replace(ZABCDPHONENUMBER.ZFULLNUMBER, "(", ""), ")", ""), "_", ""), "-", ""), " ", ""), "+", "") as ZFULLNUMBER
+      replace(replace(replace(replace(replace(ZABCDPHONENUMBER.ZFULLNUMBER, "(", ""), ")", ""), "_", ""), "-", ""), " ", "") as ZFULLNUMBER
     FROM ZABCDRECORD
     LEFT JOIN ZABCDPHONENUMBER ON ZABCDPHONENUMBER.ZOWNER = ZABCDRECORD.Z_PK
     WHERE ZABCDPHONENUMBER.ZFULLNUMBER IS NOT NULL
     )
     SELECT
-    ZFIRSTNAME || " " || ZLASTNAME  as contact_name,
-    CASE WHEN LENGTH(ZFULLNUMBER) > ${PHONE_NUMBER_LENGTH}
-      THEN SUBSTR(ZFULLNUMBER, -${PHONE_NUMBER_LENGTH}, ${PHONE_NUMBER_LENGTH})
-      ELSE ZFULLNUMBER
-    END AS contact_phone
+    -- NOTE: the COALESCE is very important here because the || (concat operator)
+    -- returns NULL if one of the columns is NULL
+    TRIM(COALESCE(ZFIRSTNAME, " ") || " " || COALESCE(ZLASTNAME, " "))  as contact_name,
+    ${normalizePhoneNumberStatement(`ZFULLNUMBER`)} AS contact_phone
     FROM CONTACTS_CLEAN_TABLE`;
     await sqlite3Wrapper.runP(this.db, q);
     return this.name;

--- a/electron/app/tables/ContactTable.ts
+++ b/electron/app/tables/ContactTable.ts
@@ -29,7 +29,9 @@ export class ContactTable extends Table {
     SELECT
     -- NOTE: the COALESCE is very important here because the || (concat operator)
     -- returns NULL if one of the columns is NULL
-    TRIM(COALESCE(ZFIRSTNAME, " ") || " " || COALESCE(ZLASTNAME, " "))  as contact_name,
+    TRIM(
+      COALESCE(ZFIRSTNAME, " ") || " " || COALESCE(ZLASTNAME, " ")
+    ) as contact_name,
     ${normalizePhoneNumberStatement(`ZFULLNUMBER`)} AS contact_phone
     FROM CONTACTS_CLEAN_TABLE`;
     await sqlite3Wrapper.runP(this.db, q);

--- a/electron/app/tables/ContactTable.ts
+++ b/electron/app/tables/ContactTable.ts
@@ -24,12 +24,11 @@ export class ContactTable extends Table {
             replace(
               replace(
                 ZABCDPHONENUMBER.ZFULLNUMBER,
-              "(", "")
-            , ")",
-          ""),
-        "_", ""),
-      "-", ""),
-    " ", "")
+              "(", ""),
+            ")",""),
+          "_", ""),
+        "-", ""),
+      " ", "")
     as ZFULLNUMBER
       FROM ZABCDRECORD
     LEFT JOIN ZABCDPHONENUMBER ON ZABCDPHONENUMBER.ZOWNER = ZABCDRECORD.Z_PK

--- a/electron/app/tables/ContactTable.ts
+++ b/electron/app/tables/ContactTable.ts
@@ -3,13 +3,10 @@ import { TableNames } from './definitions';
 import { Table } from './Table';
 import { normalizePhoneNumberStatement } from '../utils/initUtils/constants/normalization'
 
-/*
- * NOTE: the chat.db lists the country code always.
- * The addressbook.db, however, does not always include the country code.
- * Therefore, we join on a normalized column that r
- * All phone numbers in the US/Canada are 10-digit...
- *  this assumption will not work as well for users in other countries
- */
+export const Columns = {
+  CONTACT_NAME: 'contact_name',
+  CONTACT_PHONE: 'contact_phone'
+};
 
 export class ContactTable extends Table {
   async create(): Promise<TableNames> {
@@ -21,18 +18,30 @@ export class ContactTable extends Table {
       ZABCDRECORD.ZFIRSTNAME,
       ZABCDRECORD.ZLASTNAME,
       -- TODO: I understand this is ugly... use regex.
-      replace(replace(replace(replace(replace(ZABCDPHONENUMBER.ZFULLNUMBER, "(", ""), ")", ""), "_", ""), "-", ""), " ", "") as ZFULLNUMBER
-    FROM ZABCDRECORD
+      replace(
+        replace(
+          replace(
+            replace(
+              replace(
+                ZABCDPHONENUMBER.ZFULLNUMBER,
+              "(", "")
+            , ")",
+          ""),
+        "_", ""),
+      "-", ""),
+    " ", "")
+    as ZFULLNUMBER
+      FROM ZABCDRECORD
     LEFT JOIN ZABCDPHONENUMBER ON ZABCDPHONENUMBER.ZOWNER = ZABCDRECORD.Z_PK
-    WHERE ZABCDPHONENUMBER.ZFULLNUMBER IS NOT NULL
+      WHERE ZABCDPHONENUMBER.ZFULLNUMBER IS NOT NULL
     )
     SELECT
-    -- NOTE: the COALESCE is very important here because the || (concat operator)
+    -- NOTE: the COALESCE is important here because the || (concat operator)
     -- returns NULL if one of the columns is NULL
     TRIM(
       COALESCE(ZFIRSTNAME, " ") || " " || COALESCE(ZLASTNAME, " ")
-    ) as contact_name,
-    ${normalizePhoneNumberStatement(`ZFULLNUMBER`)} AS contact_phone
+    ) as ${Columns.CONTACT_NAME},
+    ${normalizePhoneNumberStatement(`ZFULLNUMBER`)} AS ${Columns.CONTACT_PHONE}
     FROM CONTACTS_CLEAN_TABLE`;
     await sqlite3Wrapper.runP(this.db, q);
     return this.name;

--- a/electron/app/tables/WordCountTable.ts
+++ b/electron/app/tables/WordCountTable.ts
@@ -6,6 +6,8 @@ import { stopWords } from '../chatBro/constants/stopWords';
 import { objReplacementUnicode } from '../chatBro/constants/objReplacementUnicode';
 import { punctuation } from '../chatBro/constants/punctuation';
 import { TableNames } from './definitions';
+import { Columns as ContactNameColumns } from './ContactTable';
+
 
 export const Columns = {
   WORD: 'word',
@@ -19,7 +21,7 @@ export class WordCountTable extends Table {
     WITH RECURSIVE SPLIT_TEXT_TABLE (id, is_from_me, guid, text, etc) AS
     (
       SELECT
-        coalesce(h.contact_name, h.id) as id, m.is_from_me, m.guid, '', m.text || ' '
+        coalesce(h.${ContactNameColumns.CONTACT_NAME}, h.id) as id, m.is_from_me, m.guid, '', m.text || ' '
       FROM message m
       JOIN
       handle h

--- a/electron/app/tables/WordCountTable.ts
+++ b/electron/app/tables/WordCountTable.ts
@@ -19,7 +19,7 @@ export class WordCountTable extends Table {
     WITH RECURSIVE SPLIT_TEXT_TABLE (id, is_from_me, guid, text, etc) AS
     (
       SELECT
-        h.id, m.is_from_me, m.guid, '', m.text || ' '
+        coalesce(h.contact_name, h.id) as id, m.is_from_me, m.guid, '', m.text || ' '
       FROM message m
       JOIN
       handle h
@@ -33,7 +33,7 @@ export class WordCountTable extends Table {
       WHERE etc <> ''
     )
       SELECT
-        id as contact_number, text as word, is_from_me, COUNT(text) as ${Columns.COUNT}
+        id as contact, text as word, is_from_me, COUNT(text) as ${Columns.COUNT}
       FROM SPLIT_TEXT_TABLE
         WHERE TRIM(LOWER(text)) NOT IN (${stopWords})
         AND TRIM(text) NOT IN (${reactions})

--- a/electron/app/utils/initUtils/constants/directories.ts
+++ b/electron/app/utils/initUtils/constants/directories.ts
@@ -1,5 +1,6 @@
 export const appDirectoryPath = `${process.env.HOME}/.leftonread`;
 export const addressBookDBName = `AddressBook-v22.abcddb`;
+export const addressBookDBAliasName = 'addressBookDB';
 
 export const addressBookPaths = {
   original: `${process.env.HOME}/Library/Application Support/AddressBook`,

--- a/electron/app/utils/initUtils/constants/normalization.ts
+++ b/electron/app/utils/initUtils/constants/normalization.ts
@@ -1,0 +1,17 @@
+const PHONE_NUMBER_LENGTH = '10';
+const COUNTRY_CODE_SYMBOL = '+';
+
+export function normalizePhoneNumberStatement(column: string):string {
+ return `
+ CASE
+  WHEN LENGTH(replace(${column}, "${COUNTRY_CODE_SYMBOL}", "")) > ${PHONE_NUMBER_LENGTH}
+    THEN SUBSTR(
+      replace(
+        ${column}, "${COUNTRY_CODE_SYMBOL}", ""
+      )
+    -${PHONE_NUMBER_LENGTH},
+    ${PHONE_NUMBER_LENGTH}
+  )
+ ELSE ${column}
+ END`
+}

--- a/electron/app/utils/initUtils/constants/normalization.ts
+++ b/electron/app/utils/initUtils/constants/normalization.ts
@@ -18,7 +18,7 @@ export function normalizePhoneNumberStatement(column: string):string {
     THEN SUBSTR(
       replace(
         ${column}, "${COUNTRY_CODE_SYMBOL}", ""
-      )
+      ),
     -${PHONE_NUMBER_LENGTH},
     ${PHONE_NUMBER_LENGTH}
   )

--- a/electron/app/utils/initUtils/constants/normalization.ts
+++ b/electron/app/utils/initUtils/constants/normalization.ts
@@ -1,6 +1,16 @@
+/*
+ * All phone numbers in the US/Canada are 10-digit.
+ * This means that users not in US/Canada will
+ * not have contact_names and instead be left to phone numbers.
+ */
 const PHONE_NUMBER_LENGTH = '10';
 const COUNTRY_CODE_SYMBOL = '+';
 
+/*
+ * NOTE: the chat.db always lists the country code.
+ * The addressbook.db, however, does not always include the country code.
+ * Create a shared CASE WHEN statement to 'normalize' the two columns
+ */
 export function normalizePhoneNumberStatement(column: string):string {
  return `
  CASE

--- a/electron/app/utils/initUtils/index.ts
+++ b/electron/app/utils/initUtils/index.ts
@@ -90,10 +90,7 @@ export async function coreInit(): Promise<sqlite3.Database> {
    */
   await createAllChatTables(lorDB);
   // TODO: remove this. Leaving this in here for now to ensure this works for other devs.
-  const result = await sqlite3Wrapper.allP(
-    lorDB,
-    'SELECT * FROM handle'
-  );
+  const result = await sqlite3Wrapper.allP(lorDB, 'SELECT * FROM handle');
   console.log(result);
   // END: remove this.
   return lorDB;

--- a/electron/app/utils/initUtils/index.ts
+++ b/electron/app/utils/initUtils/index.ts
@@ -10,7 +10,11 @@ import {
   dirPairings,
   addressBookDBAliasName
 } from './constants/directories';
-import { findPossibleAddressBookDB, addContactNameColumn, setContactNameColumn } from '../../addressBro/util/index';
+import {
+  findPossibleAddressBookDB,
+  addContactNameColumn,
+  setContactNameColumn
+} from '../../addressBro/util/index';
 import {
   createAllChatTables,
   dropAllChatTables,
@@ -87,7 +91,7 @@ export async function coreInit(): Promise<sqlite3.Database> {
    */
   await createAllChatTables(lorDB);
   // TODO: remove this. Leaving this in here for now to ensure this works for other devs.
-  const result = await sqlite3Wrapper.allP(lorDB, 'SELECT coalesce(contact_name, id) FROM handle');
+  const result = await sqlite3Wrapper.allP(lorDB, 'SELECT * FROM handle');
   console.log(result);
   // END: remove this.
   return lorDB;


### PR DESCRIPTION
We now join to contacts automatically without even needing to prompt the user! 🎊  

Resolves https://github.com/Left-on-Read/app/issues/7

Create a contact_name column in the chat.db's `handle` table by `ATTACH`-ing the addressbookDB . This allows to do `SELECT coalesce(contact_name, id) FROM handle` in all downstream core tables. In other words, contact_name is now populated either with a phone number or a name, depending on if a name (or addressBookDB) was found.

---

Note this PR was Part 2 to resolve issue #7. The first PR was merged last month in https://github.com/Left-on-Read/app/pull/19/files
