### PR TITLE
Rename Word Count to WordOrEmoji

### DIFF
--- a/electron/src/chatBro/queries/TopFriends/TopFriends.ts
+++ b/electron/src/chatBro/queries/TopFriends/TopFriends.ts
@@ -2,7 +2,7 @@ import * as sqlite3 from 'sqlite3';
 
 import * as sqlite3Wrapper from '../../../utils/initUtils/sqliteWrapper';
 
-export const Columns = {
+const Columns = {
   COUNT: 'count',
   PHONE_NUMBER: 'phone_number',
   FRIEND: 'friend',

--- a/electron/src/chatBro/queries/WordOrEmoji/WordOrEmoji.ts
+++ b/electron/src/chatBro/queries/WordOrEmoji/WordOrEmoji.ts
@@ -6,7 +6,7 @@ import * as sqlite3Wrapper from '../../../utils/initUtils/sqliteWrapper';
 import { ChatTableNames } from '../../../tables';
 import { Columns } from '../../../tables/Core/Count';
 
-function isFromMeFilter(opts: WordCountTypes.Options): string | undefined {
+function isFromMeFilter(opts: WordOrEmojiTypes.Options): string | undefined {
   if (opts.isFromMe === true) {
     return `${Columns.IS_FROM_ME} = 1`;
   }
@@ -16,14 +16,14 @@ function isFromMeFilter(opts: WordCountTypes.Options): string | undefined {
   return undefined;
 }
 
-function wordFilter(opts: WordCountTypes.Options): string | undefined {
+function wordFilter(opts: WordOrEmojiTypes.Options): string | undefined {
   if (_.isEmpty(opts.word)) {
     return undefined;
   }
   return `${Columns.WORD} = "${opts.word}"`;
 }
 
-function isEmojiFilter(opts: WordCountTypes.Options): string | undefined {
+function isEmojiFilter(opts: WordOrEmojiTypes.Options): string | undefined {
   if (opts.isEmoji === true) {
     return `TRIM(${Columns.WORD}) IN (${emojis})`;
   }
@@ -34,7 +34,7 @@ function isEmojiFilter(opts: WordCountTypes.Options): string | undefined {
 }
 
 // Attaches each filter in a combined WHERE clause.
-function getAllFilters(opts: WordCountTypes.Options): string {
+function getAllFilters(opts: WordOrEmojiTypes.Options): string {
   const isEmoji = isEmojiFilter(opts);
   const isFromMe = isFromMeFilter(opts);
   const word = wordFilter(opts);
@@ -44,8 +44,8 @@ function getAllFilters(opts: WordCountTypes.Options): string {
 
 export async function queryEmojiOrWordCounts(
   db: sqlite3.Database,
-  opts: WordCountTypes.Options = {}
-): Promise<WordCountTypes.Results> {
+  opts: WordOrEmojiTypes.Options = {}
+): Promise<WordOrEmojiTypes.Results> {
   const limit = opts.limit || 15;
   const filters = getAllFilters(opts);
   const query = `

--- a/electron/src/chatBro/queries/WordOrEmoji/types.d.ts
+++ b/electron/src/chatBro/queries/WordOrEmoji/types.d.ts
@@ -1,4 +1,4 @@
-declare namespace WordCountTypes {
+declare namespace WordOrEmojiTypes {
   interface Options {
     contact?: string;
     word?: string;

--- a/electron/src/chatBro/queries/index.ts
+++ b/electron/src/chatBro/queries/index.ts
@@ -1,4 +1,4 @@
-import { queryEmojiOrWordCounts } from './WordCount/WordCount';
+import { queryEmojiOrWordCounts } from './WordOrEmoji/WordOrEmoji';
 import { queryTopFriends } from './TopFriends/TopFriends';
 
 export { queryEmojiOrWordCounts, queryTopFriends };

--- a/electron/src/components/charts/WordOrEmojiCountChart.tsx
+++ b/electron/src/components/charts/WordOrEmojiCountChart.tsx
@@ -6,7 +6,7 @@ import * as chatBro from '../../chatBro';
 import interpolateColors from '../../utils/colors';
 import ChartLoader from '../loading/ChartLoader';
 
-interface WordCountProps {
+interface WordOrEmojiCountProps {
   db: sqlite3.Database;
   titleText: string;
   labelText: string;
@@ -14,7 +14,7 @@ interface WordCountProps {
   colorInterpolationFunc: (t: number) => string;
 }
 
-export default function WordCountChart(props: WordCountProps) {
+export default function WordOrEmojiCountChart(props: WordOrEmojiCountProps) {
   const { db, colorInterpolationFunc, titleText, labelText, isEmoji } = props;
   const [words, setWords] = useState<string[]>([]);
   const [count, setCount] = useState<number[]>([]);
@@ -22,12 +22,12 @@ export default function WordCountChart(props: WordCountProps) {
   useEffect(() => {
     async function fetchWordData() {
       try {
-        const wordCountDataList = await chatBro.queryEmojiOrWordCounts(db, {
+        const data = await chatBro.queryEmojiOrWordCounts(db, {
           isEmoji,
           isFromMe: true,
         });
-        setWords(wordCountDataList.map((obj) => obj.word));
-        setCount(wordCountDataList.map((obj) => obj.count));
+        setWords(data.map((obj) => obj.word));
+        setCount(data.map((obj) => obj.count));
       } catch (err) {
         log.error(`ERROR fetching for component for ${titleText}`, err);
       }

--- a/electron/src/index.tsx
+++ b/electron/src/index.tsx
@@ -7,7 +7,7 @@ import './app.global.css';
 import { interpolateCool } from 'd3-scale-chromatic';
 import { coreInit } from './utils/initUtils';
 
-import WordCountChart from './components/charts/WordCountChart';
+import WordOrEmojiCountChart from './components/charts/WordOrEmojiCountChart';
 import TopFriendsChart from './components/charts/TopFriendsChart';
 
 export default function Root() {
@@ -28,7 +28,7 @@ export default function Root() {
   if (db) {
     return (
       <div>
-        <WordCountChart
+        <WordOrEmojiCountChart
           db={db}
           titleText="Top Words"
           labelText="Count of Word"
@@ -40,7 +40,7 @@ export default function Root() {
           titleText="Top Friends"
           colorInterpolationFunc={interpolateCool}
         />
-        <WordCountChart
+        <WordOrEmojiCountChart
           db={db}
           titleText="Top Emojis"
           labelText="Count of Emoji"

--- a/electron/src/tables/definitions.ts
+++ b/electron/src/tables/definitions.ts
@@ -1,7 +1,4 @@
 export enum ChatTableNames {
-  WORD_TABLE = 'word_table',
-  EMOJI_TABLE = 'emoji_table',
-  TOP_FRIENDS_TABLE = 'top_friends_table',
   CORE_COUNT_TABLE = 'core_count_table',
 }
 


### PR DESCRIPTION
Rename WordCount to WordOrEmoji* because the same queries/charts are used for both. I'm not crazy about the name WordOrEmoji but it's more clear. If you have any suggestions on this, lmk.