### PR TITLE
GroupChat Filters e2e

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -184,6 +184,7 @@
     "@types/react": "^16.9.44",
     "@types/react-dom": "^16.9.9",
     "@types/react-router-dom": "^5.1.6",
+    "@types/react-select": "^4.0.2",
     "@types/react-test-renderer": "^16.9.3",
     "@types/webpack-env": "^1.15.2",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
@@ -260,6 +261,7 @@
     "react-chartjs-2": "^2.11.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
+    "react-select": "^4.0.2",
     "recursive-copy": "^2.0.11",
     "regenerator-runtime": "^0.13.5",
     "source-map-support": "^0.5.19"

--- a/electron/src/app.global.css
+++ b/electron/src/app.global.css
@@ -6,7 +6,7 @@
 
 body {
   position: relative;
-  color: white;
+  color: black;
   height: 100vh;
   background: white;
 }

--- a/electron/src/chatBro/constants/defaultFilters.ts
+++ b/electron/src/chatBro/constants/defaultFilters.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_LIMIT = 15;

--- a/electron/src/chatBro/constants/filters.ts
+++ b/electron/src/chatBro/constants/filters.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_LIMIT = 15;
+
+export enum GroupChatFilters {
+  BOTH = 'Both Individual and Group Chats',
+  ONLY_INDIVIDUAL = 'Only Individual Conversations',
+}

--- a/electron/src/chatBro/constants/reactions.ts
+++ b/electron/src/chatBro/constants/reactions.ts
@@ -1,4 +1,4 @@
-import { delimList } from '../../utils';
+import { delimList, lowerCaseList } from '../../utils';
 
 const reactionsList = ['Laughed', 'Loved', 'Emphasized', 'Disliked', 'Liked'];
-export const reactions = delimList(reactionsList);
+export const reactions = delimList(lowerCaseList(reactionsList));

--- a/electron/src/chatBro/constants/stopWords.ts
+++ b/electron/src/chatBro/constants/stopWords.ts
@@ -195,6 +195,9 @@ const stopWordsList = [
   'take',
   'even',
   'us',
+  "don't",
+  "that's",
+  "she's",
   '”', // very weird quote, not sure what this is
 ];
 export const stopWords = delimList(lowerCaseList(stopWordsList));

--- a/electron/src/chatBro/queries/TopFriends/TopFriends.ts
+++ b/electron/src/chatBro/queries/TopFriends/TopFriends.ts
@@ -1,5 +1,5 @@
 import * as sqlite3 from 'sqlite3';
-import { DEFAULT_LIMIT } from '../../constants/defaultFilters';
+import { DEFAULT_LIMIT } from '../../constants/filters';
 import getAllFilters from './filters';
 import { Columns, OutputColumns } from './columns';
 
@@ -56,6 +56,7 @@ export async function queryTopFriends(
       received as ${OutputColumns.RECEIVED}
     FROM
       RECEIVED_TABLE
+    -- NOTE: could do a LEFT JOIN here if you want to see group chats only
     JOIN
       SENT_TABLE
     ON
@@ -65,7 +66,7 @@ export async function queryTopFriends(
     ${Object.keys(OutputColumns).join(', ')}
   FROM
     COMBINED_TABLE
-  ORDER BY total DESC
+  ORDER BY ${OutputColumns.TOTAL} DESC
   LIMIT ${limit}
   `;
 

--- a/electron/src/chatBro/queries/TopFriends/filters.ts
+++ b/electron/src/chatBro/queries/TopFriends/filters.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { Columns } from './columns';
+import { GroupChatFilters } from '../../constants/filters';
 
 function wordFilter(filters: TopFriendsTypes.Filters): string | undefined {
   if (_.isEmpty(filters.word)) {
@@ -17,12 +18,9 @@ function contactFilter(filters: TopFriendsTypes.Filters): string | undefined {
 }
 
 function groupChatFilter(filters: TopFriendsTypes.Filters): string | undefined {
-  if (filters.groupChat !== undefined) {
-    return `message.cache_roomnames ${
-      filters.groupChat ? 'IS NOT' : 'IS'
-    } NULL`;
+  if (filters.groupChat === GroupChatFilters.ONLY_INDIVIDUAL) {
+    return `message.cache_roomnames IS NULL`;
   }
-  // TODO(Danilowicz): investigate what "both" means for sent messages
   return undefined; // would query for both individual and groupchats
 }
 

--- a/electron/src/chatBro/queries/TopFriends/types.d.ts
+++ b/electron/src/chatBro/queries/TopFriends/types.d.ts
@@ -3,7 +3,7 @@ declare namespace TopFriendsTypes {
     limit?: number;
     contact?: string;
     word?: string;
-    groupChat?: boolean;
+    groupChat?: string;
   }
 
   interface ChartData {

--- a/electron/src/chatBro/queries/WordOrEmoji/WordOrEmoji.ts
+++ b/electron/src/chatBro/queries/WordOrEmoji/WordOrEmoji.ts
@@ -1,5 +1,5 @@
 import * as sqlite3 from 'sqlite3';
-import { DEFAULT_LIMIT } from '../../constants/defaultFilters';
+import { DEFAULT_LIMIT } from '../../constants/filters';
 
 import * as sqlite3Wrapper from '../../../utils/initUtils/sqliteWrapper';
 import { ChatTableNames } from '../../../tables';

--- a/electron/src/chatBro/queries/WordOrEmoji/filters.ts
+++ b/electron/src/chatBro/queries/WordOrEmoji/filters.ts
@@ -14,6 +14,13 @@ function isFromMeFilter(filters: WordOrEmojiTypes.Filters): string {
   return `${Columns.IS_FROM_ME} = 0`;
 }
 
+function contactFilter(filters: WordOrEmojiTypes.Filters): string | undefined {
+  if (_.isEmpty(filters.contact)) {
+    return undefined;
+  }
+  return `${Columns.CONTACT} = "${filters.contact}"`;
+}
+
 function wordFilter(filters: WordOrEmojiTypes.Filters): string | undefined {
   if (_.isEmpty(filters.word)) {
     return undefined;
@@ -48,11 +55,19 @@ function fluffFilter(): string {
 export default function getAllFilters(
   filters: WordOrEmojiTypes.Filters
 ): string {
+  const contact = contactFilter(filters);
   const isEmoji = isEmojiFilter(filters);
   const isFromMe = isFromMeFilter(filters);
   const word = wordFilter(filters);
   const groupChat = groupChatFilter(filters);
   const fluff = fluffFilter();
-  const filtersArray = _.compact([isFromMe, word, isEmoji, groupChat, fluff]);
+  const filtersArray = _.compact([
+    isFromMe,
+    word,
+    isEmoji,
+    groupChat,
+    fluff,
+    contact,
+  ]);
   return !_.isEmpty(filtersArray) ? `WHERE ${filtersArray.join(' AND ')}` : '';
 }

--- a/electron/src/chatBro/queries/WordOrEmoji/filters.ts
+++ b/electron/src/chatBro/queries/WordOrEmoji/filters.ts
@@ -1,6 +1,11 @@
 import _ from 'lodash';
 import { emojis } from '../../constants/emojis';
 import { Columns } from './columns';
+import { GroupChatFilters } from '../../constants/filters';
+import { reactions } from '../../constants/reactions';
+import { stopWords } from '../../constants/stopWords';
+import { objReplacementUnicode } from '../../constants/objReplacementUnicode';
+import { punctuation } from '../../constants/punctuation';
 
 function isFromMeFilter(filters: WordOrEmojiTypes.Filters): string {
   if (filters.isFromMe === true) {
@@ -23,12 +28,31 @@ function isEmojiFilter(filters: WordOrEmojiTypes.Filters): string {
   } (${emojis})`;
 }
 
+function groupChatFilter(
+  filters: WordOrEmojiTypes.Filters
+): string | undefined {
+  if (filters.groupChat === GroupChatFilters.ONLY_INDIVIDUAL) {
+    return `${Columns.CACHE_ROOMNAMES} IS NULL`;
+  }
+  return undefined; // would query for both individual and groupchats
+}
+
+function fluffFilter(): string {
+  // NOTE: Text is LOWERed at this point.
+  return `TRIM(${Columns.WORD}) NOT IN (${stopWords})
+  AND TRIM(${Columns.WORD}) NOT IN (${reactions})
+  AND unicode(TRIM(${Columns.WORD})) != ${objReplacementUnicode}
+  AND TRIM(${Columns.WORD}) NOT IN (${punctuation})`;
+}
+
 export default function getAllFilters(
   filters: WordOrEmojiTypes.Filters
 ): string {
   const isEmoji = isEmojiFilter(filters);
   const isFromMe = isFromMeFilter(filters);
   const word = wordFilter(filters);
-  const filtersArray = _.compact([isFromMe, word, isEmoji]);
+  const groupChat = groupChatFilter(filters);
+  const fluff = fluffFilter();
+  const filtersArray = _.compact([isFromMe, word, isEmoji, groupChat, fluff]);
   return !_.isEmpty(filtersArray) ? `WHERE ${filtersArray.join(' AND ')}` : '';
 }

--- a/electron/src/chatBro/queries/WordOrEmoji/types.d.ts
+++ b/electron/src/chatBro/queries/WordOrEmoji/types.d.ts
@@ -5,6 +5,7 @@ declare namespace WordOrEmojiTypes {
     isFromMe: boolean;
     limit?: number;
     isEmoji: boolean;
+    groupChat?: string;
   }
 
   interface ChartData {

--- a/electron/src/components/charts/WordOrEmojiCountChart.tsx
+++ b/electron/src/components/charts/WordOrEmojiCountChart.tsx
@@ -25,7 +25,6 @@ export default function WordOrEmojiCountChart(props: WordOrEmojiCountProps) {
         const data = await chatBro.queryEmojiOrWordCounts(db, filters);
         setWords(data.map((obj) => obj.word));
         setCount(data.map((obj) => obj.count));
-        console.log(words);
       } catch (err) {
         log.error(`ERROR fetching for component for ${titleText}`, err);
       }

--- a/electron/src/components/filters/ContactFilter.tsx
+++ b/electron/src/components/filters/ContactFilter.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Select from 'react-select';
+
+interface ContactFilterProps {
+  options: any[];
+  handleChange: (selected?: any) => void;
+  contact: any;
+}
+
+export default function ContactFilter(props: ContactFilterProps) {
+  const { contact, options, handleChange } = props;
+  return (
+    <Select defaultValue={contact} onChange={handleChange} options={options} />
+  );
+}

--- a/electron/src/components/filters/GroupChatFilter.tsx
+++ b/electron/src/components/filters/GroupChatFilter.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { GroupChatFilters } from '../../chatBro/constants/filters';
+
+interface GroupChatFilterProps {
+  groupChat: string;
+  handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function GroupChatFilter(props: GroupChatFilterProps) {
+  const { groupChat, handleChange } = props;
+
+  return (
+    <>
+      {Object.values(GroupChatFilters).map((filterOpt) => {
+        return (
+          <label key={filterOpt} htmlFor={filterOpt} style={{ color: 'black' }}>
+            <input
+              id={filterOpt}
+              key={filterOpt}
+              type="radio"
+              checked={groupChat === filterOpt}
+              onChange={handleChange}
+              value={filterOpt}
+            />
+            {filterOpt}
+          </label>
+        );
+      })}
+    </>
+  );
+}

--- a/electron/src/components/filters/GroupChatFilter.tsx
+++ b/electron/src/components/filters/GroupChatFilter.tsx
@@ -13,7 +13,7 @@ export default function GroupChatFilter(props: GroupChatFilterProps) {
     <>
       {Object.values(GroupChatFilters).map((filterOpt) => {
         return (
-          <label key={filterOpt} htmlFor={filterOpt} style={{ color: 'black' }}>
+          <label key={filterOpt} htmlFor={filterOpt}>
             <input
               id={filterOpt}
               key={filterOpt}

--- a/electron/src/index.tsx
+++ b/electron/src/index.tsx
@@ -7,7 +7,8 @@ import './app.global.css';
 import { interpolateCool } from 'd3-scale-chromatic';
 import { coreInit } from './utils/initUtils';
 import LimitFilter from './components/filters/LimitFilter';
-import { DEFAULT_LIMIT } from './chatBro/constants/defaultFilters';
+import { DEFAULT_LIMIT, GroupChatFilters } from './chatBro/constants/filters';
+import GroupChatFilter from './components/filters/GroupChatFilter';
 
 import WordOrEmojiCountChart from './components/charts/WordOrEmojiCountChart';
 import TopFriendsChart from './components/charts/TopFriendsChart';
@@ -15,6 +16,7 @@ import TopFriendsChart from './components/charts/TopFriendsChart';
 export default function Root() {
   const [db, setDB] = useState<sqlite3.Database | null>(null);
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [groupChat, setGroupChat] = useState(GroupChatFilters.ONLY_INDIVIDUAL);
 
   useEffect(() => {
     async function createInitialLoad() {
@@ -32,10 +34,22 @@ export default function Root() {
     setLimit(Number(event.target.value));
   };
 
+  const handleGroupChatChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setGroupChat(event.target.value as GroupChatFilters);
+  };
+
   if (db) {
     return (
       <div>
-        <LimitFilter handleChange={handleLimitChange} limit={limit} />
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <LimitFilter handleChange={handleLimitChange} limit={limit} />
+          <GroupChatFilter
+            handleChange={handleGroupChatChange}
+            groupChat={groupChat}
+          />
+        </div>
         <WordOrEmojiCountChart
           db={db}
           titleText="Top Sent Words"
@@ -53,7 +67,7 @@ export default function Root() {
         <TopFriendsChart
           db={db}
           titleText="Top Friends"
-          filters={{ limit, groupChat: false }}
+          filters={{ limit, groupChat }}
           colorInterpolationFunc={interpolateCool}
         />
         <WordOrEmojiCountChart

--- a/electron/src/index.tsx
+++ b/electron/src/index.tsx
@@ -52,16 +52,16 @@ export default function Root() {
         </div>
         <WordOrEmojiCountChart
           db={db}
-          titleText="Top Sent Words"
-          labelText="Count of Word"
-          filters={{ isEmoji: false, limit, isFromMe: true }}
+          titleText="Top Received Emojis"
+          labelText="Count of Emoji"
+          filters={{ isEmoji: true, limit, isFromMe: false, groupChat }}
           colorInterpolationFunc={interpolateCool}
         />
         <WordOrEmojiCountChart
           db={db}
           titleText="Top Received Words"
           labelText="Count of Word"
-          filters={{ isEmoji: false, limit, isFromMe: false }}
+          filters={{ isEmoji: false, limit, isFromMe: false, groupChat }}
           colorInterpolationFunc={interpolateCool}
         />
         <TopFriendsChart
@@ -72,7 +72,14 @@ export default function Root() {
         />
         <WordOrEmojiCountChart
           db={db}
-          titleText="Top Emojis"
+          titleText="Top Sent Words"
+          labelText="Count of Word"
+          filters={{ isEmoji: false, limit, isFromMe: true }}
+          colorInterpolationFunc={interpolateCool}
+        />
+        <WordOrEmojiCountChart
+          db={db}
+          titleText="Top Sent Emojis"
           labelText="Count of Emoji"
           filters={{ isEmoji: true, limit, isFromMe: true }}
           colorInterpolationFunc={interpolateCool}

--- a/electron/src/tables/Core/Count/index.ts
+++ b/electron/src/tables/Core/Count/index.ts
@@ -1,8 +1,4 @@
 import log from 'electron-log';
-import { reactions } from '../../../chatBro/constants/reactions';
-import { stopWords } from '../../../chatBro/constants/stopWords';
-import { objReplacementUnicode } from '../../../chatBro/constants/objReplacementUnicode';
-import { punctuation } from '../../../chatBro/constants/punctuation';
 import { Columns as ContactNameColumns } from '../../ContactTable';
 
 import * as sqlite3Wrapper from '../../../utils/initUtils/sqliteWrapper';
@@ -11,7 +7,7 @@ import { Table } from '../../Table';
 
 export enum Columns {
   WORD = 'word',
-  COUNT = 'count',
+  CACHE_ROOMNAMES = 'cache_roomnames',
   IS_FROM_ME = 'is_from_me',
   CONTACT = 'contact',
 }
@@ -20,10 +16,14 @@ export class CoreCountTable extends Table {
   async create(): Promise<TableNames> {
     const q = `
     CREATE TABLE ${this.name} AS
-    WITH RECURSIVE SPLIT_TEXT_TABLE (id, is_from_me, guid, text, etc) AS
+    WITH RECURSIVE SPLIT_TEXT_TABLE (cache_roomnames, id, is_from_me, guid, text, etc) AS
     (
       SELECT
-        coalesce(h.${ContactNameColumns.CONTACT_NAME}, h.id) as id, m.is_from_me, m.guid, '', m.text || ' '
+        m.cache_roomnames,
+        coalesce(h.${ContactNameColumns.CONTACT_NAME}, h.id) as id,
+        m.is_from_me,
+        m.guid, '',
+        m.text || ' '
       FROM message m
       JOIN
         handle h
@@ -32,21 +32,17 @@ export class CoreCountTable extends Table {
         WHERE m.text IS NOT NULL
       UNION ALL
       SELECT
-        id, is_from_me, guid, SUBSTR(etc, 0, INSTR(etc, ' ')), SUBSTR(etc, INSTR(etc, ' ')+1)
+        cache_roomnames, id, is_from_me, guid, SUBSTR(etc, 0, INSTR(etc, ' ')), SUBSTR(etc, INSTR(etc, ' ')+1)
       FROM SPLIT_TEXT_TABLE
       WHERE etc <> ''
     )
       SELECT
         id as ${Columns.CONTACT},
-        text as ${Columns.WORD},
+        LOWER(text) as ${Columns.WORD},
         is_from_me as ${Columns.IS_FROM_ME},
-        COUNT(text) as ${Columns.COUNT}
+        cache_roomnames as ${Columns.CACHE_ROOMNAMES}
       FROM SPLIT_TEXT_TABLE
-      WHERE TRIM(LOWER(text)) NOT IN (${stopWords})
-        AND TRIM(text) NOT IN (${reactions})
-        AND unicode(TRIM(LOWER(text))) != ${objReplacementUnicode}
-        AND TRIM(text) NOT IN (${punctuation})
-      GROUP BY id, text, is_from_me;
+
   `;
     await sqlite3Wrapper.runP(this.db, q);
     log.info(`Created ${this.name}`);

--- a/electron/src/utils/initUtils/index.ts
+++ b/electron/src/utils/initUtils/index.ts
@@ -46,6 +46,22 @@ export async function copyFiles(
   }
 }
 
+export async function getContactOptions(db: sqlite3.Database): Promise<any> {
+  const q = `
+  SELECT
+    COALESCE(contact_name, h.id) as value,
+    COALESCE(contact_name, h.id) as label,
+    COUNT(*) as mycount,
+    h.id
+  FROM message
+  JOIN handle h
+    ON
+      h.ROWID = handle_id
+  GROUP BY h.id
+  ORDER BY mycount DESC`;
+  return sqlite3Wrapper.allP(db, q);
+}
+
 export async function coreInit(): Promise<sqlite3.Database> {
   // TODO: logic could be added here depending on what user wants to update their chat.db
   await createAppDirectory();
@@ -84,9 +100,10 @@ export async function coreInit(): Promise<sqlite3.Database> {
     log.info('No contacts found.');
   }
   /*
-   * NOTE: Whether or not the addressBook was found, we
-   * can use a COALESECE(contact_name, handle.id)
-   * to return the name or the phone
+   * NOTE:
+   *  Whether or not the addressBook was found, we
+   *  can use a COALESCE(contact_name, handle.id)
+   *  to return the name or the phone
    */
   await createAllChatTables(lorDB);
   return lorDB;

--- a/electron/yarn.lock
+++ b/electron/yarn.lock
@@ -130,7 +130,7 @@
   dependencies:
     "@babel/types" "^7.12.7"
 
-"@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5":
+"@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.7.0":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
   dependencies:
@@ -906,7 +906,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   dependencies:
@@ -978,6 +978,89 @@
   optionalDependencies:
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
+
+"@emotion/babel-plugin@^11.0.0":
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.1.2.tgz#68fe1aa3130099161036858c64ee92056c6730b7"
+  dependencies:
+    "@babel/helper-module-imports" "^7.7.0"
+    "@babel/plugin-syntax-jsx" "^7.12.1"
+    "@babel/runtime" "^7.7.2"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.5"
+    "@emotion/serialize" "^1.0.0"
+    babel-plugin-macros "^2.6.1"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "^4.0.3"
+
+"@emotion/cache@^11.0.0", "@emotion/cache@^11.1.3":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.1.3.tgz#c7683a9484bcd38d5562f2b9947873cf66829afd"
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
+
+"@emotion/css@^11.0.0":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.1.3.tgz#9ed44478b19e5d281ccbbd46d74d123d59be793f"
+  dependencies:
+    "@emotion/babel-plugin" "^11.0.0"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+
+"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+
+"@emotion/react@^11.1.1":
+  version "11.1.4"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.1.4.tgz#ddee4247627ff7dd7d0c6ae52f1cfd6b420357d2"
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.0.tgz#1a61f4f037cf39995c97fc80ebe99abc7b191ca9"
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
+
+"@emotion/unitless@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+
+"@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+
+"@emotion/weak-memoize@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
 
 "@eslint/eslintrc@^0.2.2":
   version "0.2.2"
@@ -1489,6 +1572,12 @@
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
 
+"@types/react-dom@*":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^16.9.9":
   version "16.9.10"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.10.tgz#4485b0bec3d41f856181b717f45fd7831101156f"
@@ -1510,11 +1599,25 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-select@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-4.0.2.tgz#fae357370637e0c387c26fda0d0b4853c46ad2e1"
+  dependencies:
+    "@types/react" "*"
+    "@types/react-dom" "*"
+    "@types/react-transition-group" "*"
+
 "@types/react-test-renderer@^16.9.3":
   version "16.9.4"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.4.tgz#377ccf51ea25c656b08aa474fb8194661009b865"
   dependencies:
     "@types/react" "^16"
+
+"@types/react-transition-group@*":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
+  dependencies:
+    "@types/react" "*"
 
 "@types/react@*":
   version "17.0.0"
@@ -2295,6 +2398,14 @@ babel-plugin-jest-hoist@^26.6.2:
     "@babel/types" "^7.3.3"
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-macros@^2.6.1:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    cosmiconfig "^6.0.0"
+    resolve "^1.12.0"
 
 babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
@@ -3133,7 +3244,7 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   dependencies:
@@ -3178,6 +3289,16 @@ cosmiconfig@^5.0.0:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
+
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
 
 cosmiconfig@^7.0.0:
   version "7.0.0"
@@ -3734,6 +3855,13 @@ doctrine@^3.0.0:
 dom-accessibility-api@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+
+dom-helpers@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -5270,7 +5398,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   dependencies:
@@ -5487,7 +5615,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   dependencies:
@@ -6853,6 +6981,10 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
+memoize-one@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+
 memory-fs@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
@@ -8217,7 +8349,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:
@@ -8375,6 +8507,12 @@ react-dom@^17.0.1:
     object-assign "^4.1.1"
     scheduler "^0.20.1"
 
+react-input-autosize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -8414,6 +8552,19 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-select@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-4.0.2.tgz#4dcca9f38d6a41e01f2dc7673e244a325e3b4e0e"
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/cache" "^11.0.0"
+    "@emotion/css" "^11.0.0"
+    "@emotion/react" "^11.1.1"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-input-autosize "^3.0.0"
+    react-transition-group "^4.3.0"
+
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
@@ -8438,6 +8589,15 @@ react-test-renderer@^17.0.1:
     react-is "^17.0.1"
     react-shallow-renderer "^16.13.1"
     scheduler "^0.20.1"
+
+react-transition-group@^4.3.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^17.0.1:
   version "17.0.1"
@@ -9268,7 +9428,7 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -9587,6 +9747,10 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis@^4.0.3:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.6.tgz#0d8b97b6bc4748bea46f68602b6df27641b3c548"
 
 sumchecker@^3.0.1:
   version "3.0.1"
@@ -10513,7 +10677,7 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
 
-yaml@^1.10.0:
+yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
 


### PR DESCRIPTION
- Add group chat filtering

Note: it's unfortunate but there's no known easy way to do ONLY_GROUP_CHATS (where expected behavior is sent and received between people only in group chats). It's only "Both" or "Only Individual Convos". I need to dig deeper but I think this is because `message.cache_names IS NOT NULL` gives you all group chats in which you _never_ sent a message because `is_from_me = 1` and `message.cache_names IS NOT NULL` does not exist.